### PR TITLE
Initialize payload deployer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration for payload-deployer
+PAYLOAD_SECRET=
+DATABASE_URI=
+S3_ENDPOINT=
+PORT=3000
+SITE_NAME=example
+SITE_DOMAIN=example.com
+TRUST_PROXY=1

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -1,0 +1,43 @@
+name: CI Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Enable pnpm
+        run: corepack enable pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Build and push image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}:latest .
+          docker push ghcr.io/${{ github.repository }}:latest
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            /srv/${{ secrets.SITE_NAME }}/scripts/deploy-update.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Node modules
+node_modules/
+# environment files
+.env
+# logs
+npm-debug.log*
+
+# Docker artifacts
+volume_data/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Multi-stage build for Payload CMS
+# Uses Node 20 on Alpine Linux
+
+# Base stage with Node runtime
+FROM node:20-alpine AS base
+
+# Stage for installing dependencies
+FROM base AS deps
+# libc6-compat is often required for Next.js
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies using the available lockfile
+COPY package.json pnpm-lock.yaml* package-lock.json* yarn.lock* ./
+RUN \
+  if [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm install --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  else echo "No lockfile found" && exit 1; fi
+
+# Builder stage
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Build without requiring DB connection
+RUN corepack enable pnpm && pnpm exec next build --experimental-build-mode compile
+
+# Production stage
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
+
+COPY --from=builder /app/public ./public
+RUN mkdir .next && chown nextjs:nodejs .next
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+CMD ["node", "server.js"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-# payload-deployer
+# Payload Deployer
+
+Automates the deployment of [Payload CMS](https://github.com/payloadcms/payload) on a Debian based VPS using Docker.
+This repository provides Docker configuration, helper scripts and a GitHub Actions workflow
+for quickly provisioning new Payload CMS sites.
+
+## Features
+
+- Multi-stage `Dockerfile` producing a minimal image
+- `docker-compose.yml` including PostgreSQL and MinIO
+- `init-site.sh` script for initializing a new site on a server
+- `deploy-update.sh` for updating an existing site
+- CI workflow to build and deploy images to your server
+
+## Getting Started
+
+### Prerequisites
+
+- Debian based server with Docker, Docker Compose and Traefik
+- SSH access to the server
+- A domain pointing to the server
+
+### Environment Variables
+
+Copy `.env.example` to `.env` and adjust the variables:
+
+- `PAYLOAD_SECRET` – secret used to encrypt Payload data
+- `DATABASE_URI` – PostgreSQL connection string
+- `S3_ENDPOINT` – URL of the MinIO instance
+- `PORT` – port the application should listen on
+- `SITE_NAME` – identifier for the site
+- `SITE_DOMAIN` – domain served by Traefik
+- `TRUST_PROXY` – set to `1` when running behind a proxy
+
+### Initialize a Site
+
+Run the following on your server:
+
+```sh
+sudo ./scripts/init-site.sh
+```
+
+The script clones this repository to `/srv/<site>` and creates a systemd service
+that manages the Docker Compose project. The service is enabled automatically.
+
+### Deploy Updates
+
+Once changes are pushed to the `main` branch, the GitHub Actions workflow builds
+a Docker image and deploys it to the server by running `deploy-update.sh` over
+SSH. You can also run the script manually:
+
+```sh
+cd /srv/<site>
+sudo ./scripts/deploy-update.sh
+```
+
+### Troubleshooting
+
+- Ensure environment variables are correctly set in `.env`.
+- Check `systemctl status <site>.service` for service logs.
+- Use `docker compose logs` to inspect container output.
+
+## License
+
+This project is released under the [MIT License](LICENSE).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+services:
+  payload:
+    build: .
+    env_file:
+      - .env
+    environment:
+      PAYLOAD_SECRET: ${PAYLOAD_SECRET}
+      DATABASE_URI: ${DATABASE_URI}
+      S3_ENDPOINT: ${S3_ENDPOINT}
+      PORT: ${PORT}
+      TRUST_PROXY: ${TRUST_PROXY}
+    ports:
+      - "${PORT}:3000"
+    depends_on:
+      - db
+      - minio
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${SITE_NAME}.rule=Host(`$SITE_DOMAIN`)"
+      - "traefik.http.routers.${SITE_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.${SITE_NAME}.tls.certresolver=lets-encrypt"
+    networks:
+      - web
+      - internal
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: payload
+      POSTGRES_USER: payload
+      POSTGRES_PASSWORD: payload
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - internal
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    volumes:
+      - minio_data:/data
+    networks:
+      - internal
+
+networks:
+  web:
+    external: true
+  internal:
+    driver: bridge
+
+volumes:
+  pgdata:
+  minio_data:

--- a/scripts/deploy-update.sh
+++ b/scripts/deploy-update.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Deploy updates for Payload CMS site
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SITE_DIR=$(dirname "$SCRIPT_DIR")
+cd "$SITE_DIR"
+
+docker compose pull
+# run migrations in a temporary container
+docker compose run --rm payload pnpm payload migrate
+# restart services with updated images
+docker compose up -d

--- a/scripts/init-site.sh
+++ b/scripts/init-site.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Initialize a new Payload CMS site on the server
+set -eu
+
+read -r -p "Site name: " SITE_NAME
+read -r -p "Site domain: " SITE_DOMAIN
+
+TARGET="/srv/$SITE_NAME"
+
+if [ -d "$TARGET" ]; then
+  echo "Directory $TARGET already exists" >&2
+  exit 1
+fi
+
+git clone https://github.com/your-user/payload-deployer.git "$TARGET"
+
+cp "$TARGET/.env.example" "$TARGET/.env"
+
+PAYLOAD_SECRET=$(openssl rand -hex 32)
+DATABASE_URI="postgres://payload:payload@db:5432/payload"
+S3_ENDPOINT="http://minio:9000"
+PORT=3000
+TRUST_PROXY=1
+
+sed -i "s/^PAYLOAD_SECRET=.*/PAYLOAD_SECRET=$PAYLOAD_SECRET/" "$TARGET/.env"
+sed -i "s|^DATABASE_URI=.*|DATABASE_URI=$DATABASE_URI|" "$TARGET/.env"
+sed -i "s|^S3_ENDPOINT=.*|S3_ENDPOINT=$S3_ENDPOINT|" "$TARGET/.env"
+sed -i "s/^PORT=.*/PORT=$PORT/" "$TARGET/.env"
+sed -i "s/^SITE_NAME=.*/SITE_NAME=$SITE_NAME/" "$TARGET/.env"
+sed -i "s/^SITE_DOMAIN=.*/SITE_DOMAIN=$SITE_DOMAIN/" "$TARGET/.env"
+sed -i "s/^TRUST_PROXY=.*/TRUST_PROXY=$TRUST_PROXY/" "$TARGET/.env"
+
+SERVICE_FILE="/etc/systemd/system/${SITE_NAME}.service"
+cat <<SERVICE > "$SERVICE_FILE"
+[Unit]
+Description=Payload CMS site $SITE_NAME
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=$TARGET
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable --now "${SITE_NAME}.service"
+
+echo "Site $SITE_NAME initialized at $TARGET"


### PR DESCRIPTION
## Summary
- add MIT license and gitignore
- add Dockerfile for Payload CMS
- configure docker-compose with postgres and minio
- provide env example
- add init and deploy scripts
- add CI workflow for building and deploying via SSH
- document usage in README

## Testing
- `sh -n scripts/init-site.sh`
- `sh -n scripts/deploy-update.sh`
- `shellcheck scripts/init-site.sh scripts/deploy-update.sh`

------
https://chatgpt.com/codex/tasks/task_b_68421c48692c832dbc096f512ad3fac4