### PR TITLE
Fix pnpm cache step in CI

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -9,15 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - uses: actions/setup-node@v3
         with:
           node-version: 20
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Enable pnpm
-        run: corepack enable pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
## Summary
- install pnpm before calling setup-node cache

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684223ddcae0832da7502072409e1437