### PR TITLE
Make CI optional for Node

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,14 +10,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
+        if: ${{ hashFiles('package.json') != '' }}
         with:
           version: 8
       - uses: actions/setup-node@v3
+        if: ${{ hashFiles('package.json') != '' }}
         with:
           node-version: 20
       - name: Install dependencies
+        if: ${{ hashFiles('package.json') != '' }}
         run: pnpm install --frozen-lockfile
       - name: Build
+        if: ${{ hashFiles('package.json') != '' }}
         run: pnpm run build
       - name: Login to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- make Docker build succeed without a Node project by skipping installs/builds when package.json isn't present
- skip workflow Node steps if there's no package.json

## Testing
- `docker build -t payload-deployer-test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68422908c19c832db1aa73f9340f18dc