### PR TITLE
Enable pnpm in runner Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN corepack enable pnpm && pnpm exec next build --experimental-build-mode compi
 
 # Production stage
 FROM base AS runner
+RUN corepack enable pnpm
 WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup -S nodejs && adduser -S nextjs -G nodejs


### PR DESCRIPTION
## Summary
- enable pnpm with corepack in the production Docker stage

## Testing
- `shellcheck scripts/deploy-update.sh scripts/init-site.sh`

------
https://chatgpt.com/codex/tasks/task_b_68422909b6e4832da9467260aba21305