### PR TITLE
Make repo URL configurable in init-site.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,17 @@ Copy `.env.example` to `.env` and adjust the variables:
 
 ### Initialize a Site
 
-Run the following on your server:
+Run the following on your server, setting the Git repository for your Payload
+project. You can provide the URL through the `REPO_URL` environment variable or
+as the first argument to the script:
 
 ```sh
-sudo ./scripts/init-site.sh
+REPO_URL=https://github.com/your-user/your-project.git sudo ./scripts/init-site.sh
 ```
 
-The script clones this repository to `/srv/<site>` and creates a systemd service
-that manages the Docker Compose project. The service is enabled automatically.
+The script clones the specified repository to `/srv/<site>` and creates a
+systemd service that manages the Docker Compose project. The service is enabled
+automatically.
 
 ### Deploy Updates
 

--- a/scripts/init-site.sh
+++ b/scripts/init-site.sh
@@ -5,6 +5,13 @@ set -eu
 read -r -p "Site name: " SITE_NAME
 read -r -p "Site domain: " SITE_DOMAIN
 
+# Repository containing the Payload project
+REPO_URL="${1:-${REPO_URL:-}}"
+if [ -z "$REPO_URL" ]; then
+  echo "Usage: REPO_URL=<git repository> $0 [repo_url]" >&2
+  exit 1
+fi
+
 TARGET="/srv/$SITE_NAME"
 
 if [ -d "$TARGET" ]; then
@@ -12,7 +19,7 @@ if [ -d "$TARGET" ]; then
   exit 1
 fi
 
-git clone https://github.com/your-user/payload-deployer.git "$TARGET"
+git clone "$REPO_URL" "$TARGET"
 
 cp "$TARGET/.env.example" "$TARGET/.env"
 


### PR DESCRIPTION
## Summary
- make the repository used by `init-site.sh` configurable via `REPO_URL` env var or argument
- document how to set `REPO_URL` in README

## Testing
- `sh -n scripts/init-site.sh`

------
https://chatgpt.com/codex/tasks/task_b_6842290b7ba0832d9b3290c269765d43