### PR TITLE
Fix Dockerfile for builds without node deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN \
     echo "No package.json found, skipping install"; \
   fi
 
+# Ensure node_modules exists even when no dependencies are installed
+RUN mkdir -p node_modules
+
 # Builder stage
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
## Summary
- ensure the `node_modules` directory exists in the deps stage so COPY doesn't fail when there's no package.json

## Testing
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6842362d284c832da1122b1c275638c7