### PR TITLE
Improve deploy docs and workflow validation

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -37,6 +37,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Validate configuration
+        run: |
+          if [ -z "${{ secrets.SITE_NAME }}" ]; then
+            echo "Error: SITE_NAME secret is not set" >&2
+            exit 1
+          fi
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v0.1.6
         with:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ It expects:
 - `VPS_HOST` – the hostname or IP address of your server
 - `VPS_USER` – the SSH user used during deployment
 - `VPS_SSH_KEY` – private key for authenticating to the server
-- `SITE_NAME` – directory name of the site on the VPS
+- `SITE_NAME` – directory name of the site on the VPS. This value is
+  used to construct the deployment path on your server (e.g.
+  `/srv/<SITE_NAME>`). If omitted, the deploy step will fail with a
+  path like `/srv//scripts/deploy-update.sh`.
 
 Create a personal access token by visiting **Settings → Developer settings → Personal access tokens** on GitHub and selecting the `write:packages` scope. Then add all of the above values as **Repository secrets** under **Settings → Secrets and variables → Actions**.
 
@@ -75,6 +78,8 @@ sudo ./scripts/deploy-update.sh
 - Ensure environment variables are correctly set in `.env`.
 - Check `systemctl status <site>.service` for service logs.
 - Use `docker compose logs` to inspect container output.
+- If the deploy workflow fails with a path like `/srv//scripts/deploy-update.sh`,
+  verify that the `SITE_NAME` secret is configured in your repository settings.
 
 ## License
 


### PR DESCRIPTION
## Summary
- explain the `SITE_NAME` secret requirement in README
- warn about missing `SITE_NAME` in the Troubleshooting section
- add a validation step in the deploy workflow to check that `SITE_NAME` is set

## Testing
- `shellcheck scripts/init-site.sh scripts/deploy-update.sh`
- `yamllint -d relaxed .github/workflows/ci-deploy.yml`
- ❌ `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6842380677c4832db6d0f1032dc980c6