### PR TITLE
Add placeholder build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ for quickly provisioning new Payload CMS sites.
 - `init-site.sh` script for initializing a new site on a server
 - `deploy-update.sh` for updating an existing site
 - CI workflow to build and deploy images to your server
+- Placeholder `build` script in `package.json` that can be customized for your project
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Deployment helper scripts for Payload CMS",
   "private": true,
   "scripts": {
-    "test": "echo \"No tests configured\""
+    "test": "echo \"No tests configured\"",
+    "build": "echo \"No build step defined\""
   }
 }


### PR DESCRIPTION
## Summary
- add a dummy `build` script so the workflow's `pnpm run build` step doesn't fail
- mention the placeholder `build` script in the README

## Testing
- `npm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_68423b60a14c832da612813de0d922ca