### PR TITLE
Improve secret validation

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -43,6 +43,22 @@ jobs:
             echo "Error: SITE_NAME secret is not set" >&2
             exit 1
           fi
+          if [ -z "${{ secrets.VPS_HOST }}" ]; then
+            echo "Error: VPS_HOST secret is not set" >&2
+            exit 1
+          fi
+          if [ -z "${{ secrets.VPS_USER }}" ]; then
+            echo "Error: VPS_USER secret is not set" >&2
+            exit 1
+          fi
+          if [ -z "${{ secrets.VPS_SSH_KEY }}" ]; then
+            echo "Error: VPS_SSH_KEY secret is not set" >&2
+            exit 1
+          fi
+          if [ -z "${{ secrets.GHCR_TOKEN }}" ]; then
+            echo "Error: GHCR_TOKEN secret is not set" >&2
+            exit 1
+          fi
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v0.1.6
         with:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ sudo ./scripts/deploy-update.sh
 - Use `docker compose logs` to inspect container output.
 - If the deploy workflow fails with a path like `/srv//scripts/deploy-update.sh`,
   verify that the `SITE_NAME` secret is configured in your repository settings.
+- The CI workflow also checks for `GHCR_TOKEN`, `VPS_HOST`, `VPS_USER`,
+  and `VPS_SSH_KEY`. Missing secrets cause the **Validate configuration**
+  step to fail with a clear error message.
 
 ## License
 


### PR DESCRIPTION
## Summary
- validate more secrets in CI deploy workflow
- document new validations in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68424fac5a34832dbed78ec2dd7a255c