### PR TITLE
Add restart policy to compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     depends_on:
       - db
       - minio
+    restart: unless-stopped
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.${SITE_NAME}.rule=Host(`$SITE_DOMAIN`)"
@@ -32,6 +33,7 @@ services:
       POSTGRES_PASSWORD: payload
     volumes:
       - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
     networks:
       - internal
 
@@ -43,6 +45,7 @@ services:
       MINIO_ROOT_PASSWORD: minio123
     volumes:
       - minio_data:/data
+    restart: unless-stopped
     networks:
       - internal
 


### PR DESCRIPTION
## Summary
- add restart policy to docker-compose.yml for payload, db, and minio services

## Testing
- `grep -n restart -n docker-compose.yml`


------
https://chatgpt.com/codex/tasks/task_b_68425e6ea65c832d89b378649724286b