### PR TITLE
Fix Traefik domain env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - minio
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.${SITE_NAME}.rule=Host(`$SITE_DOMAIN`)"
+      - "traefik.http.routers.${SITE_NAME}.rule=Host(`${SITE_DOMAIN}`)"
       - "traefik.http.routers.${SITE_NAME}.entrypoints=websecure"
       - "traefik.http.routers.${SITE_NAME}.tls.certresolver=lets-encrypt"
     networks:


### PR DESCRIPTION
## Summary
- use `${SITE_DOMAIN}` variable in the Traefik host rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68425e9d574c832d9af4f6d865f883ef